### PR TITLE
Proxy and basic State Machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /config
+/.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1307,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync", "process"] }
 log = "0.4"
 env_logger = "0.11.8"
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -59,25 +59,29 @@ mcservernap <COMMAND> [OPTIONS]
 
 ### `listen` Options
 
-| Option        | Description                                      | Required |
-| ------------- | ------------------------------------------------ | -------- |
-| `host`        | Host or IP to bind (e.g. `0.0.0.0`)              | Yes      |
-| `port`        | Port to listen on for Minecraft clients          | Yes      |
-| `cmd`         | Command or script to launch the Minecraft server | Yes      |
-| `args...`     | Arguments passed to the server command           | No       |
-| `--rcon-port` | Port for the server’s RCON interface             | Yes      |
-| `--rcon-pass` | Password for RCON authentication                 | Yes      |
+| Option          | Description                                                            | Required |
+| --------------- | ---------------------------------------------------------------------- | -------- |
+| `host`          | Host or IP to bind (e.g. `0.0.0.0`)                                    | Yes      |
+| `port`          | Port to listen on for Minecraft clients                                | Yes      |
+| `cmd`           | Command or script to launch the Minecraft server                       | Yes      |
+| `args...`       | Arguments passed to the server command                                 | No       |
+| `--server-port` | Port of the actual Minecraft Server that users will get forwarded to   | Yes      |
+| `--rcon-port`   | Port for the server’s RCON interface                                   | Yes      |
+| `--rcon-pass`   | Password for RCON authentication                                       | Yes      |
+
+> [!NOTE]
+> The port of the Minecraft server does not require port forwarding, only the port of this application.
 
 #### Example
 
 ```bash
-mcservernap listen 0.0.0.0 25565 java -Xmx5G -Xms5G -jar server.jar nogui --rcon-port 25575 --rcon-pass rconpasswordmeow
+mcservernap listen 0.0.0.0 25565 java -Xmx5G -Xms5G -jar server.jar nogui --server-port 25566 --rcon-port 25575 --rcon-pass rconpasswordmeow
 ```
 
 #### Script Example
 
 ```bash
-mcservernap listen 0.0.0.0 25565 "C:\path\to\your\script\start_server.bat" --rcon-port 25575 --rcon-pass rconpasswordmeow
+mcservernap listen 0.0.0.0 25565 "C:\path\to\your\script\start_server.bat" --server-port 25566 --rcon-port 25575 --rcon-pass rconpasswordmeow
 ```
 **IMPORTANT: When using a script, make sure the script closes its window at the end of the script (Windows .bat example: `exit`), or else this application won't detect that the Minecraft server process has shut down!**
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,8 +187,10 @@ pub async fn idle_watchdog_rcon(
             }
             Err(err) => {
                 {
+                    // Exclusively scoping all Mutex locks, even if it's not strictly necessary
                     let mut state = server_state.lock().await;
                     *state = ServerState::Stopped;
+                    log::debug!("Server state set to Stopped in idle_watchdog_rcon()");
                 }
                 return Err(err.into());
             }
@@ -199,8 +201,8 @@ pub async fn idle_watchdog_rcon(
     log::info!("Successfully connected to RCON at {}", rcon_addr);
     {
         let mut state = server_state.lock().await;
-        log::debug!("Server state set to Running");
         *state = ServerState::Running;
+        log::debug!("Server state set to Running in idle_watchdog_rcon()");
     }
 
     // Polling loop
@@ -217,6 +219,7 @@ pub async fn idle_watchdog_rcon(
                 {
                     let mut state = server_state.lock().await;
                     *state = ServerState::Stopped;
+                    log::debug!("Server state set to Stopped in idle_watchdog_rcon()");
                 }
                 break;
             }
@@ -237,6 +240,7 @@ pub async fn idle_watchdog_rcon(
             {
                 let mut state = server_state.lock().await;
                 *state = ServerState::Stopped;
+                log::debug!("Server state set to Stopped in idle_watchdog_rcon()");
             }
             break;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,9 @@ async fn main() -> Result<()> {
                         Err(_) => continue,    // Wait for next connection
                     }
                 } else {
+                    // Server is running: proxy connection to actual Minecraft server
+                    log::info!("Proxying connection for {}", peer);
+
                     let mut server_socket = TcpStream::connect("127.0.0.1:25566").await?;
                     tokio::spawn(async move {
                         match tokio::io::copy_bidirectional(&mut client_socket, &mut server_socket)

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ enum Commands {
         /// Arguments for the command (pass all Java/batch args here)
         #[arg(num_args(0..))]
         args: Vec<String>,
+        /// Minecraft server port (use --server-port)
+        #[arg(long)]
+        server_port: u16,
         /// RCON port (use --rcon-port)
         #[arg(long)]
         rcon_port: u16,
@@ -66,6 +69,7 @@ async fn main() -> Result<()> {
             port,
             cmd,
             args,
+            server_port,
             rcon_port,
             rcon_pass,
         } => {
@@ -181,7 +185,8 @@ async fn main() -> Result<()> {
                             // Server is running: proxy connection to actual Minecraft server
                             log::info!("Proxying connection for {}", peer);
                             tokio::spawn(async move {
-                                match TcpStream::connect("127.0.0.1:25566").await {
+                                let server_addr = format!("127.0.0.1:{}", server_port);
+                                match TcpStream::connect(server_addr).await {
                                     Ok(mut server_socket) => {
                                         match tokio::io::copy_bidirectional(
                                             &mut client_socket,


### PR DESCRIPTION
This PR adds the proxy functionality which means that the TCP listener will always be active and forward connections to the Minecraft server, if it's running. This means that player clients will continuously receive connection messages and server browser MOTDs, until a RCON connection has been established.

Due to the listener constantly being active, the Minecraft server needs to bind to a different port, that is not in use. Player clients will need to connect to the port of this application, they will get forwarded to the Minecraft server, if it's online.
This adds an additional mandatory argument to this app, `--server-port`.

Aside from these changes, the `main()` flow is now based on a very basic state machine system, using a `ServerState` enum to properly manage the incoming connections based on the current state of the Minecraft server.